### PR TITLE
Add methods for objects center and bounding box

### DIFF
--- a/imaids/blocks.py
+++ b/imaids/blocks.py
@@ -303,3 +303,49 @@ class Block(_fieldsource.FieldModel):
                 subblock = _rad.ObjDivMag(subblock, div, 'Frame->Lab')
                 subblock_list.append(subblock)
             self._radia_object = _rad.ObjCnt(subblock_list)
+
+    def bounding_box(self):
+        """Bounding box of block geometrical limits.
+        
+        Raises:
+            ValueError: If there is no radia object referenced by the Block.
+
+        Returns:
+            numpy.ndarray, 3x2: Array of the form:
+                [[xmin, xmax], [ymin,ymax], [zmin,zmax]]
+                where the min and max values are the coordinates' upper and
+                lower bounds for the points forming the block geometry.
+        """
+        if self.radia_object is None:
+            raise ValueError('There is no linked Radia object.')
+        
+        points = _np.concatenate(self.shape, axis=0)
+        x = points[:,0]
+        y = points[:,1]
+        zmin = self.longitudinal_position - 0.5*self.length
+        zmax = self.longitudinal_position + 0.5*self.length
+
+        bounding_box = [[x.min(), x.max()], [y.min(), y.max()], [zmin, zmax]]
+        return _np.array(bounding_box)
+
+    def bounding_box_center(self):
+        """Coordinates of the center of the block's bounding box.
+        
+        Each coordinate is the mean of the upper and lower bounds for the
+            point cooreinates forming the block geometry.
+
+        Note that this is different from the geometrical center returned
+            by the center_point method.
+        
+        Raises:
+            ValueError: If there is no radia object referenced by the Block.
+
+        Returns:
+            list, 3: x,y,z coorinates of bounding box center.
+        """
+        if self.radia_object is None:
+            raise ValueError('There is no linked Radia object.')
+
+        center = _np.mean(self.bounding_box(), axis=1)
+        
+        return list(center)

--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -1124,7 +1124,27 @@ class FieldModel(FieldSource):
             return True
         else:
             return False
+    
+    def center_point(self):
+        """Coordinates of radia object geometrical center.
+           
+        Note that such point is different from a bounding box center.
+        
+        Raises:
+            ValueError: If there is no radia object referenced by
+                this object's radia_object attribute.
 
+        Returns:
+            list, 3: x,y,z coorinates of geometrical object center.
+        """
+
+        if self.radia_object is None:
+            raise ValueError('There is no linked Radia object.')
+        
+        centers = _np.array(_rad.ObjM(self.radia_object))[:,0]
+        center = centers.mean(axis=0)
+
+        return list(center)
 
 class FieldData(FieldSource):
 


### PR DESCRIPTION
Adding functions for aiding spacial manipulation of blocks and objects:

- A method returning an object's center, which works for every imaids object related to a radia object.
- A Block method returning its bounding box (maximun and minimum coordinates): [[xmin, xmax], [ymin, ymax], [zmin, zmax]].
- A Block method returning the center of its bounding box.