### PR TITLE
Refactor center and bounding box behaviour

### DIFF
--- a/imaids/blocks.py
+++ b/imaids/blocks.py
@@ -304,20 +304,16 @@ class Block(_fieldsource.FieldModel):
                 subblock_list.append(subblock)
             self._radia_object = _rad.ObjCnt(subblock_list)
 
-    def bounding_box(self):
-        """Bounding box of block geometrical limits.
+    def get_geometry_bounding_box(self):
+        """Geometrical limits (bounding box) of Block's input geometry
+            (shape and length).
         
-        Raises:
-            ValueError: If there is no radia object referenced by the Block.
-
         Returns:
             numpy.ndarray, 3x2: Array of the form:
                 [[xmin, xmax], [ymin,ymax], [zmin,zmax]]
                 where the min and max values are the coordinates' upper and
                 lower bounds for the points forming the block geometry.
         """
-        if self.radia_object is None:
-            raise ValueError('There is no linked Radia object.')
         
         points = _np.concatenate(self.shape, axis=0)
         x = points[:,0]
@@ -327,25 +323,3 @@ class Block(_fieldsource.FieldModel):
 
         bounding_box = [[x.min(), x.max()], [y.min(), y.max()], [zmin, zmax]]
         return _np.array(bounding_box)
-
-    def bounding_box_center(self):
-        """Coordinates of the center of the block's bounding box.
-        
-        Each coordinate is the mean of the upper and lower bounds for the
-            point cooreinates forming the block geometry.
-
-        Note that this is different from the geometrical center returned
-            by the center_point method.
-        
-        Raises:
-            ValueError: If there is no radia object referenced by the Block.
-
-        Returns:
-            list, 3: x,y,z coorinates of bounding box center.
-        """
-        if self.radia_object is None:
-            raise ValueError('There is no linked Radia object.')
-
-        center = _np.mean(self.bounding_box(), axis=1)
-        
-        return list(center)

--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -986,6 +986,17 @@ class FieldModel(FieldSource):
     def radia_object(self):
         """Number of the radia object."""
         return self._radia_object
+    
+    @property
+    def center_point(self):
+        """Vector coordinates ([x,y,z]) of radia object geometrical center."""
+
+        if self.radia_object is None:
+            raise None
+                
+        centers = _np.array(_rad.ObjM(self.radia_object))[:,0]
+        center = centers.mean(axis=0)
+        return list(center)
 
     @property
     def state(self):
@@ -1124,27 +1135,6 @@ class FieldModel(FieldSource):
             return True
         else:
             return False
-    
-    def center_point(self):
-        """Coordinates of radia object geometrical center.
-           
-        Note that such point is different from a bounding box center.
-        
-        Raises:
-            ValueError: If there is no radia object referenced by
-                this object's radia_object attribute.
-
-        Returns:
-            list, 3: x,y,z coorinates of geometrical object center.
-        """
-
-        if self.radia_object is None:
-            raise ValueError('There is no linked Radia object.')
-        
-        centers = _np.array(_rad.ObjM(self.radia_object))[:,0]
-        center = centers.mean(axis=0)
-
-        return list(center)
 
 class FieldData(FieldSource):
 


### PR DESCRIPTION
By using these recently added functions, I came to realize that the way they are put may be confusing and/or misleading.
Proposed changes:

- ```center_point``` is a block property similarly to magnetization, so it should become a ```@property``` method.
- Rename ```bounding_box``` to ```get_geometry_bounding_box```. This method yields a very specific thing: the bounding box of the **original geometry (=shape + length)** passed for creating the block. It is not a property of the Radia object, it is not updated is not generally the actual position limits of the object. Previous name was confusingly generic.
- ```bounding_box_center``` is removed. The method returned a result that could be easily obtained from ```bounding_box```, with few use cases. However, its presence is confusing because it seems that it could be similar to the center_point method, but it is not.