### PR TITLE
Fix memory problem when deleting a container object

### DIFF
--- a/imaids/blocks.py
+++ b/imaids/blocks.py
@@ -258,7 +258,7 @@ class Block(_fieldsource.FieldModel):
     def create_radia_object(self):
         """Creates the radia object."""
         if self._radia_object is not None:
-            _rad.UtiDel(self._radia_object)
+            _utils.delete_recursive(self._radia_object)
 
         if self._length == 0:
             return

--- a/imaids/cassettes.py
+++ b/imaids/cassettes.py
@@ -537,7 +537,7 @@ class Cassette(
                 from the total number of blocks.
         """
         if self._radia_object is not None:
-            _rad.UtiDel(self._radia_object)
+            _utils.delete_recursive(self._radia_object)
 
         if block_names is None:
             block_names = ['']*self.nr_blocks

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -43,6 +43,62 @@ def delete_all():
     return _rad.UtiDelAll()
 
 
+def get_info(ref):
+    """Returns string (to be printed) containing information
+        on Radia with the input reference integer.
+            
+    Args:
+        ref (int): Radia object reference whose information will be returned.
+
+    Returns:
+        str: String containing Radia object information.
+    """
+    return _rad.UtiDmp(ref)
+
+
+def get_info_all(max_ref=100000):
+    """Returns a dictionary whose keys are the integer references to all Radia
+        objects and the values are strings containing the objects information.
+          
+    Args:
+        max_ref (int, optional): Information is returned for all objects with
+            integer references up to this value. Defaults to 100000.
+
+    Returns:
+        dict: Dictionary {..., ref:str(ref), ...}, where str(ref) is a string
+            with information on the Radia object referenced by ref (integer).
+    
+    Tip:
+        Getting a list of all reference integers:
+            >>> ref_list = list(get_info_all().keys())
+    """
+    info_dict = {}
+    for ref in range(max_ref+1):
+        try:
+            info_dict[int(ref)] = _rad.UtiDmp(ref)
+        except RuntimeError:
+            pass    
+    return info_dict
+
+
+def get_info_all_str(max_ref=100000):
+    """Returns a string with information of all Radia objects, concatenating
+        the values of the dictionary returned by get_info_all(max_ref=max_ref).
+          
+    Args:
+        max_ref (int, optional): Maximum reference integer for objects
+            represented in the returned string.
+
+    Returns:
+        str: String with information on objects with ref integer up to max_ref.
+    """
+    info = get_info_all(max_ref=max_ref)
+    info_str = ''
+    for key in info:
+        info_str += (info[key] + '\n\n')
+    return info_str
+
+
 def cosine_function(z, bamp, freq, phase):
     """Cosine function with specified amplitude, frequency and phase.
 

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -29,6 +29,23 @@ def set_len_tol(absolute=1e-12, relative=1e-12):
     return _rad.FldLenTol(absolute, relative)
 
 
+def delete_recursive(ref):
+    """Recursively deletes a Radia object and all Radia objects
+        contained within it.
+            
+    Args:
+        ref (int): Integer reference for Radia object to be deleted.
+
+    Returns:
+        int: 0
+    """
+    if _rad.ObjCntSize(ref) > 0:
+        for in_ref in _rad.ObjCntStuf(ref):
+            delete_recursive(in_ref)
+    _rad.UtiDel(ref)
+    return 0
+
+    
 def delete_all():
     """Deletes all Radia objects.
 


### PR DESCRIPTION
The construction of a ```blocks.Block``` object works by creating multiple convex sub-blocks and grouping them on a single Radia container object. However, when deleting the Block object using the ```radia.UtiDel``` method, only the container was deleted. Therefore, when calling a ```Block.create_radia_object()``` method multiple times, a huge memory leak occurred. The problem is worsened by block subdivision, in which the sub-block becomes a (nested) container itself.

This improved by the new ```delete_recursive()``` function in ```utils.py```, which deletes the object and (if it is a container) all the objects within it, recursively.

Other functions were added to ```utils.py``` for finding and displaying the information on all radia objects existing in the workspace:
- ```get_info(ref)``` returns a string with information on object referenced by ```ref```.
- ```get_info_all(max_ref=max_ref)``` returns a dictionary (keyed by ```ref```) with the strings information of all objects with ref up to ```max_ref```.
- ```get_info_all_str(max_ref=max_ref)``` returns  single string with all the information on the dictionary above concatenated.

The usage of functions shows that even with the container contents deletion, some stray objects (like transformations and materials) might still persists, what is room for further improvements.

Nevertheless, the ```delete_recursive()``` function improves the situation a lot, as seem in the tests bellow:

Test 01 - two sub-blocks with 3x3x2 subdivisions - 50k calls:
```python
from imaids.blocks import Block

shape = Block.get_predefined_shape('delta_prototype')
subdivision = Block.get_predefined_subdivision('delta_prototype')
my_block = Block(
    shape, length=2, longitudinal_position=0, subdivision=subdivision)

for _ in range(int(5E4)):
    my_block.create_radia_object()

input('Done. Press any key to finish.')
```

Test 02 - one subblock with no subdivision - 1 mi calls:
```python
from imaids.blocks import Block

shape = Block.get_predefined_shape('hybrid_block')
subdivision = [[1, 1, 1]]
my_block = Block(
    shape, length=2, longitudinal_position=0, subdivision=subdivision)

for _ in range(int(1E6)):
    my_block.create_radia_object()

input('Done. Press any key to finish.')
```

With the results in memory consumption of the python.exe process:
```
            Test 01     Test 02
master    5334.7 MB   4253.3 MB
branch     208.2 MB    510.8 MB
```