### PR TITLE
Feat utils and cassette reference

### DIFF
--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -694,6 +694,7 @@ class SinusoidalFieldSource(FieldSource):
 
     def get_effective_field(self, polarization, hmax, x):
         """Calculate effective field amplitude from model.
+
         Args:
             polarization (string): String specifying the polarization of radiation.
                 Available options are:
@@ -702,6 +703,7 @@ class SinusoidalFieldSource(FieldSource):
                 'cp': Circular polarization
             hmax (int): max field harmonic to be considered.
             x (float): horizontal position to calc field [mm]
+
         Returns:
             float : effective field amplitude [T]
             float: first harmonic field amplitude [T]
@@ -716,12 +718,15 @@ class SinusoidalFieldSource(FieldSource):
             b = bvec[:, 0]
         elif polarization in ('hp', 'cp'):
             b = bvec[:, 1]
+        else:
+            raise ValueError("invalid polarization argument")
 
         freq0 = 2*_np.pi/self.period_length
-        hs = _np.array(range(1, hmax+1, 2))
+        hs = _np.arange(1, hmax+1, 2)
         freqs = hs*freq0
-        amps,*_ = _utils.fit_fourier_components(b, freqs, z)
-        beff = _np.sqrt(_np.sum(_np.power(amps/hs, 2)))
+        amps, *_ = _utils.fit_fourier_components(b, freqs, z)
+        amps /= hs
+        beff = _np.sqrt(_np.sum(_np.dot(amps, amps)))
         return beff, amps[0], b
 
     def calc_field_amplitude(
@@ -1168,6 +1173,7 @@ class FieldModel(FieldSource):
             return True
         else:
             return False
+
 
 class FieldData(FieldSource):
 

--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -796,8 +796,9 @@ class SinusoidalFieldSource(FieldSource):
         """
         if bx_amp is None or by_amp is None:
             bx_amp, by_amp, _, _ = self.calc_field_amplitude()
-        kh = 0.934*by_amp*(self.period_length/10)
-        kv = 0.934*bx_amp*(self.period_length/10)
+        period = self.period_length*1e-3
+        kh = _utils.calc_deflection_parameter(b_amp=by_amp, period_length=period)
+        kv = _utils.calc_deflection_parameter(b_amp=bx_amp, period_length=period)
         return kh, kv
 
     def calc_trajectory_avg_over_period(self, trajectory):

--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -692,10 +692,14 @@ class SinusoidalFieldSource(FieldSource):
         nr_periods = int(len(dz)/2)
         return avg_period_length, nr_periods
 
-    def get_beff(self, polarization, hmax, x):
+    def get_effective_field(self, polarization, hmax, x):
         """Calculate effective field amplitude from model.
         Args:
-            polarization (string): polarization of radiation. (['hp', 'vp', 'cp'])
+            polarization (string): String specifying the polarization of radiation.
+                Available options are:
+                'hp': Horizontal polarization
+                'vp': Vertical polarization
+                'cp': Circular polarization
             hmax (int): max field harmonic to be considered.
             x (float): horizontal position to calc field [mm]
         Returns:

--- a/imaids/insertiondevice.py
+++ b/imaids/insertiondevice.py
@@ -155,6 +155,11 @@ class InsertionDeviceModel(
         return _deepcopy(self._cassettes)
 
     @property
+    def cassettes_ref(self):
+        """Reference to cassettes dictionary."""
+        return self._cassettes
+
+    @property
     def cassette_properties(self):
         """Common cassettes properties."""
         return self._cassette_properties

--- a/imaids/models.py
+++ b/imaids/models.py
@@ -1792,7 +1792,7 @@ class HybridPlanar(Planar):
                 gap, period_length)
 
         block_len = (
-            period_length/2 - pole_length - longitudinal_distance)
+            period_length/2 - pole_length - 2*longitudinal_distance)
 
         lenghts = [0, block_len/2, pole_length/2, block_len]
         distances = [0, pole_length, pole_length, longitudinal_distance]

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -149,12 +149,10 @@ def calc_beff_vs_gap_fit(gap_over_period, beff, br):
     a0, b0, c0 = 2, -3, 0
 
     def fit_function(x, a, b, c):
-        return br*a*_np.exp(b*x + c*(x**2))
+        return br*a*_np.exp(b*x + c*(x*x))
 
-    opt = _optimize.curve_fit(
+    return _optimize.curve_fit(
         fit_function, gap_over_period, beff, p0=(a0, b0, c0))[0]
-
-    return opt
 
 
 def calc_deflection_parameter(b_amp, period_length):
@@ -167,10 +165,10 @@ def calc_deflection_parameter(b_amp, period_length):
     Returns:
         float: deflection parameter
     """
-    ELEMENTARY_CHARGE = 1.60217662e-19  # [C]
-    ELECTRON_MASS = 9.10938356e-31  # [Kg]
-    LIGHT_SPEED = 299792458  # [m/s]
-    return ELEMENTARY_CHARGE * period_length * b_amp / (2 * _np.pi * ELECTRON_MASS * LIGHT_SPEED)
+    e = 1.60217662e-19  #Electron charge [C]
+    m = 9.10938356e-31  #Electron mass [Kg]
+    c = 299792458  #Light speed [m/s]
+    return e * period_length * b_amp / (2 * _np.pi * m * c)
 
 
 def hybrid_undulator_pole_length(gap, period_length):
@@ -420,21 +418,16 @@ def mh_tesla_curve(hlist, mlist=None, blist=None, msksi=None):
     not_none = int(sum(x is not None for x in [mlist, blist, msksi]))
 
     if not_none == 1:
-
         mu0_hlist = _np.array(hlist)*VACUUM_PERMEABILITY
-
         if mlist is not None:
             mu0_mlist = _np.array(mlist)*VACUUM_PERMEABILITY
-
         elif blist is not None:
             mu0_mlist = _np.array(blist) - _np.array(hlist)*VACUUM_PERMEABILITY
-        
         elif msksi is not None:
             if depth(msksi) == 2:
                 mu0_mlist = sum(paramag_model(mu0_hlist, *l) for l in msksi)
             else:
                 raise ValueError('msksi has wrong depth (must be 2)')
-
     else:
         raise ValueError('{:d} inputs were given '.format(not_none) + \
             'for calculating magnetization (must use 1)')

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -7,9 +7,6 @@ import radia as _rad
 
 # NOTE: package lnls-sirius/mathphys could be used to defined these consts
 
-ELEMENTARY_CHARGE = 1.60217662e-19  # [C]
-ELECTRON_MASS = 9.10938356e-31  # [Kg]
-LIGHT_SPEED = 299792458  # [m/s]
 VACUUM_PERMEABILITY = 1.25663706212e-6  # [V.s/A/m]
 
 
@@ -136,39 +133,6 @@ def cosine_function(z, bamp, freq, phase):
     return bamp*_np.cos(freq*z + phase)
 
 
-def get_beff_from_model(model, period, polarization, hmax, x):
-    """Calculate effective field amplitude from model.
-
-    Args:
-        model (radia object): ID model.
-        period (float): ID period.
-        polarization (string): polarization of radiation. (['hp', 'vp', 'cp'])
-        hmax (int): max field harmonic to be considered.
-        x (float): horizontal position to calc field [mm]
-
-    Returns:
-        float : effective field amplitude [T]
-        float: first harmonic field amplitude [T]
-        numpy.ndarray: field along longitudinal positions [T]
-    """
-    zmin = -2*period
-    zmax = 2*period
-    npts = 201
-    z = _np.linspace(zmin, zmax, npts)
-    bvec = model.get_field(x=x,z=z)
-    if polarization == 'vp':
-        b = bvec[:, 0]
-    elif polarization in ('hp', 'cp'):
-        b = bvec[:, 1]
-
-    freq0 = 2*_np.pi/period
-    hs = _np.array(range(1, hmax+1, 2))
-    freqs = hs*freq0
-    amps,*_ = fit_fourier_components(b, freqs, z)
-    beff = _np.sqrt(_np.sum(_np.power(amps/hs, 2)))
-    return beff, amps[0], b
-
-
 def get_beff_fit(gap_over_period, beff, br):
     """Return fitted B(Gap/period) exponential curve parameters."""
     a0, b0, c0 = 2, -3, 0
@@ -184,12 +148,10 @@ def get_beff_fit(gap_over_period, beff, br):
 
 def undulator_b_to_k(b, period):
     """Field amplitude to K conversion."""
+    ELEMENTARY_CHARGE = 1.60217662e-19  # [C]
+    ELECTRON_MASS = 9.10938356e-31  # [Kg]
+    LIGHT_SPEED = 299792458  # [m/s]
     return ELEMENTARY_CHARGE * period * b / (2 * _np.pi * ELECTRON_MASS * LIGHT_SPEED)
-
-
-def undulator_k_to_b(k, period):
-    """K to field amplitude conversion."""
-    return (2 * _np.pi * ELECTRON_MASS * LIGHT_SPEED * k) / (ELEMENTARY_CHARGE * period)
 
 
 def hybrid_undulator_pole_length(gap, period_length):

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -133,8 +133,19 @@ def cosine_function(z, bamp, freq, phase):
     return bamp*_np.cos(freq*z + phase)
 
 
-def get_beff_fit(gap_over_period, beff, br):
-    """Return fitted B(Gap/period) exponential curve parameters."""
+def calc_beff_vs_gap_fit(gap_over_period, beff, br):
+    """Return fitted B(Gap/period) exponential curve parameters.
+
+    Args:
+        gap_over_period (numpy 1darray): Values of gap/period in which we have data
+             for the effective field.
+        beff (numpy 1darray): Effective field data (For each value of gap/period there
+            is a correspondent value of effective field)
+        br (float): Remnant magnetization
+    
+    Returns:
+        opt (list, 3): List with the values of the curve parameters
+    """
     a0, b0, c0 = 2, -3, 0
 
     def fit_function(x, a, b, c):

--- a/imaids/utils.py
+++ b/imaids/utils.py
@@ -157,12 +157,20 @@ def calc_beff_vs_gap_fit(gap_over_period, beff, br):
     return opt
 
 
-def undulator_b_to_k(b, period):
-    """Field amplitude to K conversion."""
+def calc_deflection_parameter(b_amp, period_length):
+    """Field amplitude or Effective field to K conversion.
+
+    Args:
+        b_amp (float): Field amplitude or Effective field(Beff)
+        period_length (float): Period length [m]
+
+    Returns:
+        float: deflection parameter
+    """
     ELEMENTARY_CHARGE = 1.60217662e-19  # [C]
     ELECTRON_MASS = 9.10938356e-31  # [Kg]
     LIGHT_SPEED = 299792458  # [m/s]
-    return ELEMENTARY_CHARGE * period * b / (2 * _np.pi * ELECTRON_MASS * LIGHT_SPEED)
+    return ELEMENTARY_CHARGE * period_length * b_amp / (2 * _np.pi * ELECTRON_MASS * LIGHT_SPEED)
 
 
 def hybrid_undulator_pole_length(gap, period_length):


### PR DESCRIPTION
This PR includes new features on imaids.utils and a method to reference a cassette without making a copy.
Here are the features implemented:

calc_beff_from-model - Given a model, this function calculates the effective field using the fourier components.

get_beff_fit - Given points of a Beff vs gap/period curve this function calculates the coeficients of the exponential curve which best fits the data.

undulator_b_to_k - Given b and the period length it returns k

undulator_k_to_b - Given k and the period length it returns b

All these functions were copied with some modifications from the repository "ids-specs" on gitlab