### PR TITLE
Fix block transformations shimming

### DIFF
--- a/examples/solve_by_sections.py
+++ b/examples/solve_by_sections.py
@@ -33,10 +33,16 @@ import imaids
 
 
 # Specifying undulator model.
+# With the trf_on_blocks=True argument, transformations are applied to the
+# blocks when setting up the undulator cassette positions. This is important
+# since this script uses the blocks individually, outside the cassettes.
+# trf_on_blocks defaults to False, in which case the transformations would be
+# applied to the cassettes and the bocks would loose them if used individually.
 und = imaids.models.HybridPlanar(nr_periods=10,
                                      period_length=20,
                                      gap=5,
-                                     mr=1.37)
+                                     mr=1.37,
+                                     trf_on_blocks=True)
 
 # For later field calculations.
 z = np.linspace(-1200, 1200, 4801)

--- a/imaids/insertiondevice.py
+++ b/imaids/insertiondevice.py
@@ -113,7 +113,7 @@ class InsertionDeviceModel(
 
     def __init__(
             self, nr_periods=None, period_length=None, gap=None, name=None,
-            init_radia_object=True, **kwargs):
+            init_radia_object=True, trf_on_blocks=False, **kwargs):
         """Insertion device model class.
 
         Args:
@@ -126,6 +126,10 @@ class InsertionDeviceModel(
             name (str, optional): Insertion device name. Defaults to None.
             init_radia_object (bool, optional): If True, create a radia
                 object. Defaults to True.
+            trf_on_blocks (bool, optional): If True, transformations will be
+                applied to blocks when cassettes are positioned. Otherwise,
+                transformations are applied to the cassettes themselves.
+                Defaults to False.
 
         Raises:
             ValueError: Magnetic gap must be bigger than zero.
@@ -140,6 +144,7 @@ class InsertionDeviceModel(
 
         self._cassette_properties = kwargs
         self._cassettes = {}
+        self.trf_on_blocks = trf_on_blocks
         self._radia_object = None
         if init_radia_object:
             self.create_radia_object()

--- a/imaids/models.py
+++ b/imaids/models.py
@@ -92,9 +92,13 @@ class Delta(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cse.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in cse.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            cse.shift([0, -self._gap/2, 0])
+            cse.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = cse
 
         name = 'csd'
@@ -106,9 +110,13 @@ class Delta(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in csd.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
+        if self.trf_on_blocks:
+            for block in csd.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
+        else:
+            csd.shift([0, -self._gap/2, 0])
+            csd.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
         self._cassettes[name] = csd
 
         name = 'cie'
@@ -120,9 +128,13 @@ class Delta(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cie.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
+        if self.trf_on_blocks:
+            for block in cie.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
+        else:
+            cie.shift([0, -self._gap/2, 0])
+            cie.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
         self._cassettes[name] = cie
 
         name = 'cid'
@@ -134,8 +146,11 @@ class Delta(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cid.blocks:
-            block.shift([0, -self._gap/2, 0])
+        if self.trf_on_blocks:
+            for block in cid.blocks:
+                block.shift([0, -self._gap/2, 0])
+        else:
+            cid.shift([0, -self._gap/2, 0])
         self._cassettes[name] = cid
 
         self._radia_object = _rad.ObjCnt(
@@ -327,9 +342,13 @@ class AppleX(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cse.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in cse.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            cse.shift([0, -self._gap/2, 0])
+            cse.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = cse
 
         name = 'csd'
@@ -341,9 +360,13 @@ class AppleX(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in csd.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
+        if self.trf_on_blocks:
+            for block in csd.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
+        else:
+            csd.shift([0, -self._gap/2, 0])
+            csd.rotate([0, 0, 0], [0, 0, 1], -_np.pi/2)
         self._cassettes[name] = csd
 
         name = 'cie'
@@ -355,9 +378,13 @@ class AppleX(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cie.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
+        if self.trf_on_blocks:    
+            for block in cie.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
+        else:
+            cie.shift([0, -self._gap/2, 0])
+            cie.rotate([0, 0, 0], [0, 0, 1], _np.pi/2)
         self._cassettes[name] = cie
 
         name = 'cid'
@@ -369,8 +396,11 @@ class AppleX(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cid.blocks:
-            block.shift([0, -self._gap/2, 0])
+        if self.trf_on_blocks:    
+            for block in cid.blocks:
+                block.shift([0, -self._gap/2, 0])
+        else:
+            cid.shift([0, -self._gap/2, 0])
         self._cassettes[name] = cid
 
         self._radia_object = _rad.ObjCnt(
@@ -551,10 +581,15 @@ class AppleII(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cse.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.mirror([0, 0, 0], [1, 0, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in cse.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.mirror([0, 0, 0], [1, 0, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            cse.shift([0, -self._gap/2, 0])
+            cse.mirror([0, 0, 0], [1, 0, 0])
+            cse.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = cse
 
         name = 'csd'
@@ -566,9 +601,13 @@ class AppleII(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in csd.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in csd.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            csd.shift([0, -self._gap/2, 0])
+            csd.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = csd
 
         name = 'cie'
@@ -580,8 +619,11 @@ class AppleII(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cie.blocks:
-            block.shift([0, -self._gap/2, 0])
+        if self.trf_on_blocks:    
+            for block in cie.blocks:
+                block.shift([0, -self._gap/2, 0])
+        else:
+            cie.shift([0, -self._gap/2, 0])
         self._cassettes[name] = cie
 
         name = 'cid'
@@ -593,9 +635,13 @@ class AppleII(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cid.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.mirror([0, 0, 0], [1, 0, 0])
+        if self.trf_on_blocks:    
+            for block in cid.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.mirror([0, 0, 0], [1, 0, 0])
+        else:
+            cid.shift([0, -self._gap/2, 0])
+            cid.mirror([0, 0, 0], [1, 0, 0])
         self._cassettes[name] = cid
 
         self._radia_object = _rad.ObjCnt(
@@ -700,9 +746,13 @@ class APU(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cs.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in cs.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            cs.shift([0, -self._gap/2, 0])
+            cs.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = cs
 
         name = 'ci'
@@ -714,8 +764,11 @@ class APU(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in ci.blocks:
-            block.shift([0, -self._gap/2, 0])
+        if self.trf_on_blocks:
+            for block in ci.blocks:
+                block.shift([0, -self._gap/2, 0])
+        else:
+            ci.shift([0, -self._gap/2, 0])
         self._cassettes[name] = ci
 
         self._radia_object = _rad.ObjCnt(
@@ -795,9 +848,13 @@ class Planar(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in cs.blocks:
-            block.shift([0, -self._gap/2, 0])
-            block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        if self.trf_on_blocks:
+            for block in cs.blocks:
+                block.shift([0, -self._gap/2, 0])
+                block.rotate([0, 0, 0], [0, 0, 1], _np.pi)
+        else:
+            cs.shift([0, -self._gap/2, 0])
+            cs.rotate([0, 0, 0], [0, 0, 1], _np.pi)
         self._cassettes[name] = cs
 
         name = 'ci'
@@ -809,8 +866,11 @@ class Planar(_insertiondevice.InsertionDeviceModel):
             block_names=block_names_dict.get(name),
             magnetization_list=magnetization_dict.get(name),
             position_err=position_err_dict.get(name))
-        for block in ci.blocks:
-            block.shift([0, -self._gap/2, 0])
+        if self.trf_on_blocks:
+            for block in ci.blocks:
+                block.shift([0, -self._gap/2, 0])
+        else:
+            ci.shift([0, -self._gap/2, 0])
         self._cassettes[name] = ci
 
         self._radia_object = _rad.ObjCnt(


### PR DESCRIPTION
In a previous commit (578d630a4f87fe8a311803e135f75ac3f9f4d298), the models code was changed so that the transformations were applied to the blocks instead of the cassettes when setting up the cassettes positions.

This was needed for the `solve_by_sections.py` example, since it uses the blocks individually. If the transformation were applied to the cassette, the block would have no transformation when used by the example code.

However, it turns out that this new behavior breaks the shimming procedure, since the shims are applied to all models using:
```python
blocks[idx].shift([0, shim, 0])
```
What only works as expected if the block has no rotation transformation.

This branch fixes this by making the old transformation method the default again and adding a `trf_on_blocks` argument to the insertion device models which is `False` by default and triggers the new "transformation applied to blocks" procedure if set to `True`.

The `solve_by_sections.py`  example is also updated.