### PR TITLE
Fix zero length termination blocks

### DIFF
--- a/imaids/cassettes.py
+++ b/imaids/cassettes.py
@@ -624,7 +624,8 @@ class Cassette(
         magnetization_list = magnetization_list.tolist()
 
         if self.hybrid:
-            mag0 = magnetization_list[0]
+            # Magnetization of first core object.
+            mag0 = magnetization_list[self.nr_start_blocks]
             # Check if first block has (mx,my,mz) with |my|>|mz|
             # to determine wether it is a core block or pole.
             if _np.abs(mag0[1]) > _np.abs(mag0[2]):

--- a/imaids/cassettes.py
+++ b/imaids/cassettes.py
@@ -423,8 +423,8 @@ class Cassette(
 
     @property
     def magnetization_list(self):
-        """List of magnetization vectors READ FROM RADIA OBJECTS [T].
-            
+        """List of magnetization vectors attributes from blocks.
+
         This getter method will return the current magnetizations of the
         blocks, regardless of how they were set (including start and
         end blocks).

--- a/imaids/models.py
+++ b/imaids/models.py
@@ -1536,10 +1536,10 @@ class Kyma22(APU):
 
         block_len = period_length/4 - longitudinal_distance
         lenghts = [
-            block_len/2, 0, block_len, block_len/2,
+            block_len/2, block_len, block_len/2,
             block_len, block_len]
         distances = [
-            block_len/4, 0, block_len/4, block_len/4,
+            block_len/4, block_len/4, block_len/4,
             longitudinal_distance, longitudinal_distance]
 
         if start_blocks_length == 'default':
@@ -1622,10 +1622,10 @@ class Kyma58(APU):
 
         block_len = period_length/4 - longitudinal_distance
         lenghts = [
-            block_len/2, 0, block_len, block_len/2,
+            block_len/2, block_len, block_len/2,
             block_len, block_len]
         distances = [
-            block_len/4, 0, block_len/4, block_len/4,
+            block_len/4, block_len/4, block_len/4,
             longitudinal_distance, longitudinal_distance]
 
         if start_blocks_length == 'default':
@@ -1737,8 +1737,8 @@ class HybridAPU(APU):
         block_len = (
             period_length/2 - pole_length - 2*longitudinal_distance)
 
-        lenghts = [0, block_len/2, pole_length/2, block_len]
-        distances = [0, pole_length, pole_length, longitudinal_distance]
+        lenghts = [block_len/2, pole_length/2, block_len]
+        distances = [pole_length, pole_length, longitudinal_distance]
 
         if start_blocks_length == 'default':
             start_blocks_length = lenghts
@@ -1854,8 +1854,8 @@ class HybridPlanar(Planar):
         block_len = (
             period_length/2 - pole_length - 2*longitudinal_distance)
 
-        lenghts = [0, block_len/2, pole_length/2, block_len]
-        distances = [0, pole_length, pole_length, longitudinal_distance]
+        lenghts = [block_len/2, pole_length/2, block_len]
+        distances = [pole_length, pole_length, longitudinal_distance]
 
         if start_blocks_length == 'default':
             start_blocks_length = lenghts


### PR DESCRIPTION
This PR eliminates 'zero-length' termination blocks that were used in hybrid undulators. These have 3 termination blocks, as implemented here, but used a further zero length block for making the number of blocks even.

A correction on the statement which checks wether the first core element is a block or a pole was done. Now the code will correctly determine if the first core element is a pole or a block regardless of the number of start blocks (it is acually a correcton to the `is_pole` check added in the commit https://github.com/lnls-ima/insertion-devices/commit/a4a56e5179e11cfaa9408fc8b1db881086583284).

A correction on a docstring was also made.