### PR TITLE
Add option for shimming blocks in pairs

### DIFF
--- a/imaids/shimming.py
+++ b/imaids/shimming.py
@@ -37,14 +37,18 @@ class UndulatorShimming():
                 dictionary of the considered insertion device model.
             block_type (str, optional): String specifying which types of blocks
                 will be used for shimming. Available options are:
-                'v' :   Vertical, blocks whose magnetization points mostly to
-                        the y direction ("vertical" up or down transversal).
-                'vpos'  Vertical positive, blocks whose magnetization points
-                        mostly to the positive y direction ("vertical" up
-                        transversal)
-                'vneg'  Vertical negative, blocks whose magnetization points
-                        mostly to the negative y direction ("vertical" down
-                        transversal)
+                'v'     : Vertical, blocks whose magnetization points mostly to
+                          the y direction ("vertical" up or down transversal).
+                'vpos'  : Vertical positive, blocks whose magnetization points
+                          mostly to the positive y direction ("vertical" up
+                          transversal)
+                'vneg'  : Vertical negative, blocks whose magnetization points
+                          mostly to the negative y direction ("vertical" down
+                          transversal)
+                'vlpair': Pairs of vertical ('v') and their next adjacent block
+                          (longitudinal) used for shimming. Both blocks of a
+                          pair are displaced together by the same shift during
+                          the shimming procedure.
                 Defaults to 'v'.
             segments_type (str, optional): Defines how field zeros are used to
                 obtain segments limits. Such zeros are the zeros z positions of
@@ -90,7 +94,7 @@ class UndulatorShimming():
                 matrix. Otherwise, solve method is not run. Defaults to False.
 
         Raises:
-            ValueError: If block_type is not 'v', 'vpos' or 'vneg'.
+            ValueError: If block_type is not allowed.
             ValueError: If segments_type is not "period" or "half_period".
         """
         if block_type not in ('v', 'vpos', 'vneg', 'vlpair'):
@@ -329,7 +333,8 @@ class UndulatorShimming():
                 File format:
                     Lines corresponding to optimizable parameters (slopes and,
                         possibly, phase errors) and columns corresponding to
-                        specific blocks used for shimming.
+                        individual shims (each one consisting in displacing
+                        one block or a pair of blocks).
         Returns:
             numpy.ndarray: Response matrix (same format as the output
                 from the calc_response_matrix method).
@@ -436,7 +441,8 @@ class UndulatorShimming():
         Args:
             filename (str): Name of file with names.
                 File format:
-                    One name per line.
+                    Each line contains the block names corresponding to
+                    a single shim.
 
         Returns:
             numpy.ndarray: Array of block names.
@@ -657,9 +663,9 @@ class UndulatorShimming():
     def get_block_names(self, model, filename=None, flatten=False):
         """Get list of names for the blocks used in shimming.
 
-        Thesse blocks are selected from the cassettes in the cassettes object
-        attribute and filtered accordint to block_type attribute (see help on
-        get_shimming_blocks for details on the filtering).
+        The blocks are selected from the cassettes in the cassettes attribute
+        and filtered and grouped accordint to block_type attribute (see help
+        on get_shimming_blocks for details on the filtering and grouping).
 
         Model must be an instance of InsertionDeviceModel or of a derivate
         class AND must have non-empty cassettes dictionary (see help on
@@ -680,7 +686,8 @@ class UndulatorShimming():
                 to a 1d array. Defaults to False.
 
         Returns:
-            numpy.ndarray: list of names for blocks used in shimming.
+            numpy.ndarray, NxM: array of names for blocks used in shimming
+                (N sets/elements of M blocks).
         """
         access_names = _np.vectorize(lambda block: block.name)
         for cassette in self.cassettes:
@@ -711,9 +718,15 @@ class UndulatorShimming():
                 dictionary of the model.
 
         Returns:
-            numpy.ndarray: Array containing blocks.Block objects listed from
-                specified cassette and filtered acording to block_type object
-                attribute (only non-termination blocks are included).
+            numpy.ndarray, NxM: Array containing blocks.Block objects.
+                The blocks are filtered from the specified cassette and
+                grouped according to the block_type. Only non-termination
+                blocks are included.
+                The array shape represents N shimming elements, each one
+                conssisting of M blocks. In the 'v', 'vpos' and 'vneg' cases,
+                each element is a single block (Nx1). For the 'vlpair' case,
+                each element is an array of two blocks (Nx2), and each block
+                is displaced as a single unit during the shimming procedure.
         """
         cas = model.cassettes[cassette]
         mag = _np.array(cas.magnetization_list)
@@ -778,16 +791,28 @@ class UndulatorShimming():
     def calc_response_matrix(
             self, model, model_segs, filename=None, shim=0.1):
         """Calculate response matrix associated to the effect of individual
-        blocks shimming to a set of optimizable parammeters, which include
-        segment slopes and, possibly (if include_pe==True), phase errors.
+        shims to a set of optimizable parammeters, including segment slopes,
+        and, possibly (if include_pe==True), phase errors.
+
+        Each shim consists in displacing a single block by a small positive
+        shift (local y+) or displacing a set of blocks together.
+            Examples:
+            'vneg'  : a shim, related a single row of the shimming matrix, is
+                      the displacement of a single "vertical negative" block
+                      (magnetization pointing to local y-).
+            'vlpair': a shim, related a single row of the shimming matrix, is
+                      the simultaneous displacement of a pair of blocks, a
+                      vertical one and a longitudinal one (y+, z-) or (y-, z+).
+        Thus, self.block_type specifies the blocks and their grouping, while
+        self.cassettes specifies the cassettes from which blocks are selected.
+
+        The slopes (optimizable parameters) are determined with respect to
+        the given segment limits list. Phase errors are determined by the
+        calc_phase_error method from the input model.
+
+        The resulting matirix represents the linear operation:
 
             (optimizable parameters) = (response matrix) @ (shims)
-
-        The matrix is computed for a specific radia insertion device model.
-        > Slopes are determined with respect to given segment limits list.
-        > Blocks considered for shimming are taken from specific cassettes
-          and filtered by a specific block_type, both are inputs at the
-          UndulatorShimming object initizlization.
 
         Model must be an instance of InsertionDeviceModel or of a derivate
         class AND must have non-empty cassettes dictionary.
@@ -807,25 +832,23 @@ class UndulatorShimming():
                 creating output files. If this argument is given, the following
                 files are created:
                     name_mx.extension: in which each line contains the x slopes
-                        derivatives with respect to shim for a given block.
+                        derivatives with respect to a given shim.
                     name_my.extension: in which each line contains the y slopes
-                        derivatives with respect to shim for a given block.
+                        derivatives with respect to a given shim.
                     name_mpe.extension: in which each line contains the phase
-                        errors with respect to shim for a given block
-                        (empty if include_pe==False).
+                        error derivatives with respect to a given shim.
                     name.extension: response matrix, in which each line
-                        corresponds to an optimized parameter (slopes and,
+                        corresponds to an optimizable parameter (slopes and,
                         possibly, phase errors) and each column corresponds
-                        to a shimmed block.
+                        to a given shim.
                 Defaults to None.
-            shim (float, optional): Small displacement (shim) value applied to
-                each block (individually) for determining the response matrix.
-                In mm. Defaults to 0.1.
+            shim (float, optional): Displacement (shim) value applied to blocks
+                for determining the response matrix. In mm. Defaults to 0.1.
 
         Returns:
             numpy.ndarray: Response matrix, containing one line per optimized
                 parameter (slopes and, possibly, phase errors) and one column
-                per shimmed block.
+                per shim.
         """
         response_matrix = None
 
@@ -1000,10 +1023,8 @@ class UndulatorShimming():
             model (InsertionDeviceModel): Model used for calculating fields
                 before and after shimming.
             shims (numpy.ndarray): List of shims for which signature is to
-                be calculated. List should contain one value for each block
-                used for shimming (from self.cassettes and of type given by
-                block_type) and must not contain more elements than available
-                blocks.
+                be calculated. The block displacement represented by such
+                list are determined by self.cassettes and self.block_type.
             filename (str, optional): If provided, resulting field map will
                 be saved in a file with name filename.
                     File format:
@@ -1219,6 +1240,8 @@ class UndulatorShimming():
                 when plotting y component of trajectory. Defaults to None.
             pe_lim (list, 2, optional): Vertical axis lower and upper limits
                 when plotting phase errors. Defaults to None.
+            figsize (tuple, 2, optional): Pair of floats specifying figure size
+                Defaults to (12, 6).
         """
         labels = list(results.keys())
 

--- a/imaids/shimming.py
+++ b/imaids/shimming.py
@@ -664,7 +664,7 @@ class UndulatorShimming():
         """Get list of names for the blocks used in shimming.
 
         The blocks are selected from the cassettes in the cassettes attribute
-        and filtered and grouped accordint to block_type attribute (see help
+        and filtered and grouped according to block_type attribute (see help
         on get_shimming_blocks for details on the filtering and grouping).
 
         Model must be an instance of InsertionDeviceModel or of a derivate
@@ -791,7 +791,7 @@ class UndulatorShimming():
     def calc_response_matrix(
             self, model, model_segs, filename=None, shim=0.1):
         """Calculate response matrix associated to the effect of individual
-        shims to a set of optimizable parammeters, including segment slopes,
+        shims to a set of optimizable parameters, including segment slopes,
         and, possibly (if include_pe==True), phase errors.
 
         Each shim consists in displacing a single block by a small positive
@@ -810,7 +810,7 @@ class UndulatorShimming():
         the given segment limits list. Phase errors are determined by the
         calc_phase_error method from the input model.
 
-        The resulting matirix represents the linear operation:
+        The resulting matrix represents the linear operation:
 
             (optimizable parameters) = (response matrix) @ (shims)
 
@@ -1015,7 +1015,7 @@ class UndulatorShimming():
 
     def calc_shim_signature(self, model, shims, filename=None):
         """Calculate the field difference between the non-shimmed and
-        the shimmed insertion device (shiming signature).
+        the shimmed insertion device (shimming signature).
 
         Model may be an instance of InsertionDeviceModel or any derivate class.
 
@@ -1037,7 +1037,7 @@ class UndulatorShimming():
             InsertionDeviceData: Data object with the same number of periods,
                 period length and gap as the input model object.
                 Contains the resulting signature field (difference between
-                shimemd and unshimmed fields) in the format of raw_data.
+                shimmemd and unshimmed fields) in the format of raw_data.
                 (List of x, y, z positions and mm and bx, by, bz fields in T)
         """
         zpos = _np.linspace(self.zmin, self.zmax, self.znpts)
@@ -1136,7 +1136,7 @@ class UndulatorShimming():
         return shimmed_meas
 
     def calc_results(self, objs, labels, xls=None, yls=None, filename=None):
-        """Recieves a list of objects, calculates various for them (see Returns
+        """Receives a list of objects, calculates various for them (see Returns
             section), and compiles the results in a nested dictionary.
             Dictionary entries are keyed by the labels argument. Entries are
             dictionaries themselves, compiling the results for the objects.
@@ -1230,7 +1230,7 @@ class UndulatorShimming():
                 from calc_results method.
             table_fontsize (int, optional): Table font size. Defaults to 12.
             table_decimals (int, optional): Number of decimals for rounding
-                values diaplaied in table. Defaults to 1.
+                values displayed in table. Defaults to 1.
             filename (str, optional): If not None, represents file in which
                 figure is saved. Defaults to None.
             suptitle (str, optional): Title for figure. Defaults to None.

--- a/imaids/shimming.py
+++ b/imaids/shimming.py
@@ -654,7 +654,7 @@ class UndulatorShimming():
 
         return sx, sy, pe
 
-    def get_block_names(self, model, filename=None):
+    def get_block_names(self, model, filename=None, flatten=False):
         """Get list of names for the blocks used in shimming.
 
         Thesse blocks are selected from the cassettes in the cassettes object
@@ -665,6 +665,10 @@ class UndulatorShimming():
         class AND must have non-empty cassettes dictionary (see help on
         get_shimming_blocks for details on the available built-in models).
 
+        By default, the returned numpy array will have the same shame as the
+        shimming elements array. But it may be flattened as an 1d array of
+        blocks by the 'flatten' argument.
+
         Args:
             model (InsertionDeviceModel derivate, see above): Device model
                 with the considered cassettes (cassettes attribute).
@@ -672,14 +676,18 @@ class UndulatorShimming():
                 a file in which names will be written. Defaults to None.
                 File format:
                     One name per line
+            flatten (bool, optional): If True, names array will be flattened
+                to a 1d array. Defaults to False.
 
         Returns:
-            list: list of names for blocks used in shimming.
+            numpy.ndarray: list of names for blocks used in shimming.
         """
-        names = []
+        access_names = _np.vectorize(lambda block: block.name)
         for cassette in self.cassettes:
             blocks = self.get_shimming_blocks(model, cassette)
-            names.extend([b.name for b in blocks])
+            names = access_names(blocks)
+        if flatten:
+            names = names.flatten()
         if filename is not None:
             _np.savetxt(filename, names, fmt='%s')
         return names

--- a/imaids/shimming.py
+++ b/imaids/shimming.py
@@ -847,15 +847,17 @@ class UndulatorShimming():
         for cassette in self.cassettes:
             blocks = self.get_shimming_blocks(model, cassette)
 
-            for idx in range(len(blocks)):
-                blocks[idx].shift([0, shim, 0])
+            for idx0 in range(len(blocks)):
+                for idx1 in range(len(blocks[idx0])):
+                    blocks[idx0, idx1].shift([0, shim, 0])
 
                 if self.solved_matrix:
                     model.solve()
                 sx, sy, pe = self.calc_slope_and_phase_error(
                     model, model_segs, 0, 0)
 
-                blocks[idx].shift([0, -shim, 0])
+                for idx1 in range(len(blocks[idx0])):
+                    blocks[idx0, idx1].shift([0, -shim, 0])
 
                 dpx = (sx - sx0)/shim
                 mx.append(dpx)
@@ -1023,8 +1025,9 @@ class UndulatorShimming():
         count = 0
         for cassette in self.cassettes:
             blocks = self.get_shimming_blocks(model, cassette)
-            for idx in range(len(blocks)):
-                blocks[idx].shift([0, shims[count], 0])
+            for idx0 in range(len(blocks)):
+                for idx1 in range(len(blocks[idx0])):
+                    blocks[idx0, idx1].shift([0, shims[count], 0])
                 count += 1
 
         if self.solved_shim:
@@ -1036,8 +1039,9 @@ class UndulatorShimming():
         count = 0
         for cassette in self.cassettes:
             blocks = self.get_shimming_blocks(model, cassette)
-            for idx in range(len(blocks)):
-                blocks[idx].shift([0, (-1)*shims[count], 0])
+            for idx0 in range(len(blocks)):
+                for idx1 in range(len(blocks[idx0])):
+                    blocks[idx0, idx1].shift([0, (-1)*shims[count], 0])
                 count += 1
 
         if self.solved_shim:


### PR DESCRIPTION
This adds the possibility of performing shimming using vertical-longitudinal pairs of blocks (displaced together). 
Also, the new way shimming blocks are internally organized in a numpy array allows for other block combinations to be implemented.