### PR TITLE
Feat add pole option to terminations

### DIFF
--- a/imaids/cassettes.py
+++ b/imaids/cassettes.py
@@ -129,6 +129,10 @@ class Cassette(
             end_blocks_magnetization (list, Lx3, optional): Nested list of
                 end blocks magnetizations. Analogous to corresponding list for
                 start blocks list. In Tesla, defaults to None.
+            terminations_poles (bool): If True, the block-pole-block-pole
+                sequence in a hybrid cassette extends to the termination
+                blocks. If False, all termination blocks are non-pole blocks.
+                Defaults to False.
             name (str, optional): Name labeling the cassette. Defaults to ''.
             init_radia_object (bool, optional): If True, Radia object is
                 created at object initialization. Defaults to True.

--- a/imaids/cassettes.py
+++ b/imaids/cassettes.py
@@ -12,7 +12,7 @@ from . import fieldsource as _fieldsource
 class Cassette(
         _fieldsource.FieldModel, _fieldsource.SinusoidalFieldSource):
     """Insertion device cassette.
-    
+
     The cassette is composed of magnetic blocks (blocks.Block objects),
     with specified materials, lengths and gaps, assembled in a line along
     the longitudinal direction (z).
@@ -46,28 +46,29 @@ class Cassette(
             start_blocks_length=None, start_blocks_distance=None,
             end_blocks_length=None, end_blocks_distance=None,
             start_blocks_magnetization=None, end_blocks_magnetization=None,
+            start_poles=None, end_poles=None,
             name='', init_radia_object=True):
         """Gathers cassette properties from arguments and calls method for
             creating Radia object.
 
         Args:
             nr_periods (int): Number of complete periods.
-            period_length (float, optional): Period length in mm.             
+            period_length (float, optional): Period length in mm.
             block_shape (list, Mx2 or NxMx2): List defining blocks
                 geometry. Single list or N nested lists of M 2D points defining
                 convex polygons which form the cross-section of a block (as
                 described in blocks.Block). In mm.
             mr (float, optional): magnitude of remanent magnetization vector
                 Defines magnetization vector modulus for linear material used
-                at the blocks. In Tesla. Must be >= 0. Defaults to 1.37.  
+                at the blocks. In Tesla. Must be >= 0. Defaults to 1.37.
             upper_cassette (bool, optional): Defines direction of the first
                 core block magnetization and, consequentely, the directions
                 sequency for the Halbach array period used:
-                    If True:   y+, z-, y-, z+ 
+                    If True:   y+, z-, y-, z+
                     If False:  y-, z+, y+, z-
                     With:
                         y+ : (0, 1, 0)   ;   z+ : (0, 0, 1)
-                        y- : (0,-1, 0)   ;   z- : (0, 0,-1) 
+                        y- : (0,-1, 0)   ;   z- : (0, 0,-1)
                 Defaults to False.
             longitudinal_distance (int, optional): Longitudinal gap between
                 adjacent core blocks or between core blocks and poles in the
@@ -87,12 +88,12 @@ class Cassette(
                 easy axis (magnetization diraction). Defaults to 0.17.
             hybrid (bool, optional): If True, hybrid undulator cassette is
                 created with alternating blocks and poles. If False, cassette
-                is created with only blocks. Defaults to False.                
+                is created with only blocks. Defaults to False.
             pole_shape (list, Mx2 or NxMx2, optional): Pole shape in the same
                 format as block_shape, in mm. If None pole shape will be the
-                same as block shape. Defaults to None. 
+                same as block shape. Defaults to None.
             pole_length (float, optional): Pole length in mm.
-                If hybrid==True, must be not None. Defaults to None.                
+                If hybrid==True, must be not None. Defaults to None.
             pole_material (materials.Material, optional): Material applyed to
                 poles blocks.Block objects, which are generated with [0,0,0]
                 initial magnetization.
@@ -100,7 +101,7 @@ class Cassette(
             pole_subdivision (list, 3 or Nx3, optional): Pole subdivision in
                 the same format as block_subdivision. Must have same N length
                 of pole_shape (or block_shape, if pole_shape==None).
-                Defaults to None, meaning no subdivision.       
+                Defaults to None, meaning no subdivision.
             start_blocks_length (list, K, optional): List of K block lengths,
                 one length for each start block, in mm. Only used if both
                 start_blocks_length and start_blocks_distance are not None.
@@ -109,11 +110,11 @@ class Cassette(
                 one for each start block, in which each distance is the gap
                 AFTER the corresponding block, in mm. Only used if both
                 start_blocks_length and start_blocks_distance are not None.
-                Defaults to None.            
+                Defaults to None.
             end_blocks_length (list, L, optional): List of L block lengths,
                 one length for each end block, in mm. Only used if both
                 end_blocks_length and end_blocks_distance are not None.
-                Defaults to None.            
+                Defaults to None.
             end_blocks_distance (list, L optional): List of L distances,
                 one for each end block, in which each distance is the gap
                 BEFORE the corresponding block, in mm. Only used if both
@@ -128,15 +129,15 @@ class Cassette(
             end_blocks_magnetization (list, Lx3, optional): Nested list of
                 end blocks magnetizations. Analogous to corresponding list for
                 start blocks list. In Tesla, defaults to None.
-            name (str, optional): Name labeling the cassette. Defaults to ''.             
+            name (str, optional): Name labeling the cassette. Defaults to ''.
             init_radia_object (bool, optional): If True, Radia object is
                 created at object initialization. Defaults to True.
-            
+
         Note1: length of core blocks is not given by an initialization argument,
         but determined by the number of periods, period length, longitudinal
         distance and (possibly, if hybrid==True) pole length. Such length
         determination is performed by the create_radia_object method.
-        
+
         Note2: 4 arguments may be provided for defining cassette materials:
             mr, ksipar, ksiper and pole_material.
             Blocks have linear anisotropic material, with ksipar and ksiper.
@@ -151,7 +152,7 @@ class Cassette(
             * Radia is used by imaids in such a way that magnetization
               direction is always defined at the object level, never at
               material level.
-            
+
         Raises:
             ValueError: If mr < 0.
             ValueError: If longitudinal_distance < 0.
@@ -188,7 +189,7 @@ class Cassette(
         if start_blocks_length and start_blocks_distance:
             msg = 'Inconsistent start blocks lists.'+ \
                     f'\n lengths: {len(start_blocks_length)}'+ \
-                    f'\n distances: {len(start_blocks_distance)}'                    
+                    f'\n distances: {len(start_blocks_distance)}'
             if start_blocks_magnetization:
                 start_check = (len(start_blocks_length)
                                 == len(start_blocks_distance)
@@ -200,7 +201,7 @@ class Cassette(
             if not start_check:
                 raise ValueError(msg)
             self._start_blocks_length = start_blocks_length
-            self._start_blocks_distance = start_blocks_distance            
+            self._start_blocks_distance = start_blocks_distance
         else:
             self._start_blocks_length = []
             self._start_blocks_distance = []
@@ -208,7 +209,7 @@ class Cassette(
         if end_blocks_length and end_blocks_distance:
             msg = 'Inconsistent end blocks lists.'+ \
                     f'\nlengths: {len(end_blocks_length)}'+ \
-                    f'\ndistances: {len(end_blocks_distance)}'           
+                    f'\ndistances: {len(end_blocks_distance)}'
             if end_blocks_magnetization:
                 end_check = (len(end_blocks_length)
                                 == len(end_blocks_distance)
@@ -220,7 +221,7 @@ class Cassette(
             if not end_check:
                 raise ValueError(msg)
             self._end_blocks_length = end_blocks_length
-            self._end_blocks_distance = end_blocks_distance            
+            self._end_blocks_distance = end_blocks_distance
         else:
             self._end_blocks_length = []
             self._end_blocks_distance = []
@@ -230,6 +231,8 @@ class Cassette(
 
         self._hybrid = hybrid
         if self._hybrid:
+            self._start_poles = start_poles
+            self._end_poles = end_poles
             if pole_shape is None:
                 pole_shape = block_shape
             if pole_length is None:
@@ -254,7 +257,7 @@ class Cassette(
         self._radia_object = None
         if init_radia_object:
             self.create_radia_object()
-        
+
         # Also, there are the following @property methods which are not
         # directly obtained from the __init__ arguments:
         # > nr_start_blocks
@@ -278,7 +281,7 @@ class Cassette(
     def period_length(self):
         """Period length [mm]."""
         return self._period_length
-    
+
     @property
     def block_shape(self):
         """Block list of shapes [mm]."""
@@ -287,7 +290,7 @@ class Cassette(
     @property
     def mr(self):
         """Remanent magnetization [T]."""
-        return self._mr    
+        return self._mr
 
     @property
     def upper_cassette(self):
@@ -318,17 +321,17 @@ class Cassette(
     def ksiper(self):
         """Perpendicular magnetic susceptibility."""
         return self._ksiper
-    
+
     @property
     def hybrid(self):
         """True for hybrid cassette, False otherwise."""
         return self._hybrid
-    
+
     @property
     def pole_shape(self):
         """Pole list of shapes [mm]."""
         return _deepcopy(self._pole_shape)
-    
+
     @property
     def pole_length(self):
         """Pole length [mm]."""
@@ -370,15 +373,25 @@ class Cassette(
         return _deepcopy(self._end_blocks_magnetization)
 
     @property
+    def start_poles(self):
+        """List of boolean values, True if object is pole, False otherwise."""
+        return self._start_poles
+
+    @property
+    def end_poles(self):
+        """List of boolean values, True if object is pole, False otherwise."""
+        return self._end_poles
+
+    @property
     def position_err(self):
         """Position errors [mm]."""
         return _deepcopy(self._position_err)
-    
+
     @property
     def blocks(self):
         """List of Block objects."""
         return self._blocks
-    
+
     @property
     def is_pole_list(self):
         """List of boolean values, True if object is pole, False otherwise."""
@@ -446,7 +459,7 @@ class Cassette(
     @property
     def longitudinal_distance_list(self):
         """List of distances (gaps between objects) for Block objects [mm].
-        
+
         Between core blocks (or between core blocks and poles) there are
         nr_core_blocks-1 distances.
         This way, start_blocks_distance represents distances AFTER start blocks
@@ -535,16 +548,16 @@ class Cassette(
 
         If a Radia object bound to the Cassette object already exists, it is
             deleted before a new one is created.
-        
+
         For creating the cassette blocks.Block objects, core block length is
         also determined at this method using:
             > longitudinal distances (gap between core blocks or poles)
             > Period length
-            > Pole length, if hybrid.       
+            > Pole length, if hybrid.
             so that 4 core blocks (or 2 poles and 2 core blocks, if hybrid)
-            lead to a period of length equal to the period_length attribute. 
+            lead to a period of length equal to the period_length attribute.
 
-        Args:        
+        Args:
             block_names (list, nr_blocks, optional): List of names for the
                 blocks.Block objects forming the cassette. List length must
                 match the total number of blocks and poles (nr_blocks).
@@ -560,7 +573,7 @@ class Cassette(
                 Poles are created with their specified material (pole_meterial)
                 and [0,0,0] as their initial magnetization.
                 Examples:
-                    > For a cassette with 2 start blocks, 2 end blocks, 
+                    > For a cassette with 2 start blocks, 2 end blocks,
                         2 periods and hybrid==True, for a magnetization_list:
                             [y+, z-, y-, z+, y+, z-, y-, z+, y+, z-, y-, z+]
                         The cassette objects will be initialized with:
@@ -574,7 +587,7 @@ class Cassette(
                             |  1st period  ||  2nd Period  ||  3rd Period  |
                     Where 00 = [0,0,0].
                 If None, magnetization list will be calculated by the
-                get_ideal_magnetization_list method (Halbach array).                
+                get_ideal_magnetization_list method (Halbach array).
                 Defaults to None.
             position_err (list, nr_blocks x 3, optional): List of translations
                 additionally applied to blocks.Block objects for simulating
@@ -623,6 +636,14 @@ class Cassette(
         magnetization_list = magnetization_list.tolist()
 
         if self.hybrid:
+            # Create pole list for terminations
+            if self.start_poles is not None and self.end_poles is not None:
+                start_poles = self.start_poles
+                end_poles = self.end_poles
+            else:
+                start_poles = [False]*int(self.nr_start_blocks)
+                end_poles = [False]*int(self.nr_end_blocks)
+
             # Magnetization of first core object.
             mag0 = magnetization_list[self.nr_start_blocks]
             # Check if first block has (mx,my,mz) with |my|>|mz|
@@ -636,9 +657,9 @@ class Cassette(
                     self._end_blocks_length])
                 # is_pole_list if HYBRID and first core object is POLE
                 self._is_pole_list = _utils.flatten([
-                    [False]*int(self.nr_start_blocks),
+                    start_poles,
                     [True, False]*int(self.nr_core_blocks/2),
-                    [False]*self.nr_end_blocks])
+                    end_poles])
             else:
                 # Length_list if HYBRID and first core object is BLOCK
                 length_list = _utils.flatten([
@@ -647,10 +668,13 @@ class Cassette(
                         self.nr_core_blocks/2),
                     self._end_blocks_length])
                 # is_pole_list if HYBRID and first core object is BLOCK
+                if self.poles_on_terminations:
+                    start_poles = [not value for value in start_poles]
+                    end_poles = [not value for value in end_poles]
                 self._is_pole_list = _utils.flatten([
-                    [False]*int(self.nr_start_blocks),
+                    start_poles,
                     [False, True]*int(self.nr_core_blocks/2),
-                    [False]*self.nr_end_blocks])
+                    end_poles])
         else:
             # Length_list if NON-HYBRID
             length_list = _utils.flatten([
@@ -658,9 +682,9 @@ class Cassette(
                 [block_length]*self.nr_core_blocks,
                 self._end_blocks_length])
             # is_pole_list if NON-HYBRID
-            self._is_pole_list = [False]*(self.nr_start_blocks + 
-                                            self.nr_core_blocks + 
-                                            self.nr_end_blocks)
+            self._is_pole_list = [False]*(self.nr_start_blocks +
+                                          self.nr_core_blocks +
+                                          self.nr_end_blocks)
 
         # Positions initialy start at 0 and are defined by adding the
         # longitudinal distances (gaps) and half lengths of their two adjacent
@@ -669,7 +693,7 @@ class Cassette(
         position_list = [0]
         for i in range(1, self.nr_blocks):
             position_list.append((
-                length_list[i] + length_list[i-1])/2 + 
+                length_list[i] + length_list[i-1])/2 +
                                  self.longitudinal_distance_list[i-1])
         position_list = _np.cumsum(position_list)
         position_list -= (position_list[0] + position_list[-1])/2
@@ -727,20 +751,20 @@ class Cassette(
 
         0   1   2   3   0   1   2   3   0   1  ...
         y+  z-  y-  z+  y+  z-  y-  z+  y+  z-  ...
-        (^) (<) (v) (>) (^) (<) (v) (>) (^) (<) ...  
+        (^) (<) (v) (>) (^) (<) (v) (>) (^) (<) ...
 
         In which:
             0: is the (0,  1,  0) direction; "transversal-horizontal up"
             1: is the (0,  0, -1) direction; "longitudinal backward"
             2: is the (0  -1,  0) direction; "transversal-horizontal down"
             3: is the (0,  0,  1) direction; "longitudinal foward"
-        
+
         The final magnetization directions are defined in such a way that:
             if upper_cassette==False, the first CORE block always has
-                magnetization in direction 0; (0,+1,0) 
+                magnetization in direction 0; (0,+1,0)
             if upper_cassette==True, the first CORE block always has
                 magnetization in direction 2; (0,-1,0)
-            
+
         Example:
             * upper_cassette==True
             * 3 start blocks
@@ -795,7 +819,7 @@ class Cassette(
                     max_amplitude_error=0.02 represents 2% maximum modulus
                     error, meaning magnetization modulus between 98% and 102% of
                     the ideal value returned by get_ideal_magnetization_list().
-                Defaults to 0.                 
+                Defaults to 0.
             max_angular_error (float, optional): Maximum angular error, which
                 is the angle by which the magnetization vector will be rotated
                 around a random axis. In radians. Defaults to 0.
@@ -807,7 +831,7 @@ class Cassette(
 
         Returns:
             list Nx3: Magnetization 3-vectors of the N=nr_blocks blocks.Block
-                objects forming the cassette with random amplitude and rotation 
+                objects forming the cassette with random amplitude and rotation
                 errors in relation to an ideal Halbach arrangement.
         """
         magnetization_list = self.get_ideal_magnetization_list()

--- a/imaids/models.py
+++ b/imaids/models.py
@@ -883,12 +883,9 @@ class Planar(_insertiondevice.InsertionDeviceModel):
         name = 'ci'
         if 'start_blocks_magnetization' in self.cassette_properties.keys():
             mags = self.cassette_properties['start_blocks_magnetization']
-            print(mags)
-            print()
             mask = _np.array([1, 1, -1])
             self.cassette_properties['start_blocks_magnetization'] =\
                 (mask*mags).tolist()
-            print(self.cassette_properties['start_blocks_magnetization'])
         if 'end_blocks_magnetization' in self.cassette_properties.keys():
             mags = self.cassette_properties['end_blocks_magnetization']
             mask = _np.array([1, 1, -1])
@@ -1926,7 +1923,7 @@ class HybridPlanar(Planar):
             rectangular=False, longitudinal_distance=0.1,
             start_blocks_length='default', start_blocks_distance='default',
             end_blocks_length='default', end_blocks_distance='default',
-            start_poles='default', end_poles='default',
+            terminations_poles='default',
             name='hybrid_planar', **kwargs):
         """Create Hybrid planar model.
 
@@ -1996,11 +1993,8 @@ class HybridPlanar(Planar):
             pole_length = _utils.hybrid_undulator_pole_length(
                 gap, period_length)
 
-        if start_poles == 'default':
-            start_poles = None
-
-        if end_poles == 'default':
-            end_poles = None
+        if terminations_poles == 'default':
+            terminations_poles = False
 
         block_len = (
             period_length/2 - pole_length - 2*longitudinal_distance)
@@ -2035,7 +2029,7 @@ class HybridPlanar(Planar):
             start_blocks_distance=start_blocks_distance,
             end_blocks_length=end_blocks_length,
             end_blocks_distance=end_blocks_distance,
-            start_poles=start_poles, end_poles=end_poles,
+            terminations_poles=terminations_poles,
             name=name, **kwargs)
 
 

--- a/imaids/models.py
+++ b/imaids/models.py
@@ -1912,6 +1912,7 @@ class HybridPlanar(Planar):
             rectangular=False, longitudinal_distance=0.1,
             start_blocks_length='default', start_blocks_distance='default',
             end_blocks_length='default', end_blocks_distance='default',
+            start_poles='default', end_poles='default',
             name='hybrid_planar', **kwargs):
         """Create Hybrid planar model.
 
@@ -1981,6 +1982,12 @@ class HybridPlanar(Planar):
             pole_length = _utils.hybrid_undulator_pole_length(
                 gap, period_length)
 
+        if start_poles == 'default':
+            start_poles = None
+
+        if end_poles == 'default':
+            end_poles = None
+
         block_len = (
             period_length/2 - pole_length - 2*longitudinal_distance)
 
@@ -2014,6 +2021,7 @@ class HybridPlanar(Planar):
             start_blocks_distance=start_blocks_distance,
             end_blocks_length=end_blocks_length,
             end_blocks_distance=end_blocks_distance,
+            start_poles=start_poles, end_poles=end_poles,
             name=name, **kwargs)
 
 


### PR DESCRIPTION
This PR implements the option of having pole pieces on cassettes' terminations, as in the case of IVU18. 
Furthermore, a change in how the magnetization of start and end blocks are setted was also implemented. Now for the case of a planar ID both cassettes will have opposite magnetizations on the termination's blocks.