### PR TITLE
Add FieldData method for creating data object based no Radia model

### DIFF
--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -1410,6 +1410,28 @@ class FieldData(FieldSource):
     def raw_data(self):
         return self._raw_data
 
+    @classmethod
+    def from_model(cls, model, x, y, z):
+
+        if int(_np.ndim(x)) == 0:
+            x = [x]
+        if int(_np.ndim(y)) == 0:
+            y = [y]
+        if int(_np.ndim(z)) == 0:
+            z = [z]
+
+        if sum([len(i) > 1 for i in [x, y, z]]) == 0:
+            raise ValueError('Inputs correspond to single point')
+
+        raw_data = []
+        for pz in z:
+            for py in y:
+                for px in x:
+                    b = model.get_field_at_point([px, py, pz])
+                    raw_data.append([px, py, pz, b[0], b[1], b[2]])
+
+        return cls(raw_data=_np.array(raw_data))
+
     def _update_interpolation_functions(self):
         """Update field data using scipy interpolation functions.
             Interpolations 1D or 2D only.

--- a/imaids/fieldsource.py
+++ b/imaids/fieldsource.py
@@ -1412,6 +1412,24 @@ class FieldData(FieldSource):
 
     @classmethod
     def from_model(cls, model, x, y, z):
+        """Returns FieldData object based on field values from Radia Model.
+
+        Args:
+            model (FieldModel): Radia model used for calculating magnetic field
+                for the returned FieldData object.
+            x (list or float or int, optional): list of x positions
+                or fixed x position to get field (in mm). Defaults to 0.
+            y (list or float or int, optional): list of y positions
+                or fixed y position to get field (in mm). Defaults to 0.
+            z (list or float or int, optional): list of z positions
+                or fixed z position to get field (in mm). Defaults to 0.
+
+        Raises:
+            ValueError: x, y and z are float or int (single point not allowed).
+
+        Returns:
+            FieldData: Data object whose raw data was calculated from model.
+        """
 
         if int(_np.ndim(x)) == 0:
             x = [x]


### PR DESCRIPTION
The new method returns a ```FieldData``` object whose field data was calculated from a received radia model at a set of received positions.

Example:
```python
import numpy as np
import matplotlib.pyplot as plt
from imaids.fieldsource import FieldData
from imaids.models import DeltaSabia

und_model = DeltaSabia(nr_periods=3)
und_model.set_cassete_positions(dgv=13.125, dp=13.125)
und_model.solve()

zs = np.linspace(-250, 250, 1001)
und_data = FieldData.from_model(model=und_model, z=zs)

b_model = und_model.get_field(z=zs)
b_data = und_data.get_field(z=zs)

fig, axs = plt.subplots(2,1)
axs[0].plot(zs, b_model, label=['bx (model)', 'by (model)', 'bz (model)'])
axs[0].legend()
axs[1].plot(zs, b_data, label=['bx (data)', 'by (data)', 'bz (data)'])
axs[1].set_xlabel('z (mm)')
axs[1].legend()
plt.show()
```
![Figure_1](https://github.com/lnls-ima/insertion-devices/assets/61742723/55266657-2d8f-4a0c-8a90-13fdb52d9429)

