### PR TITLE
Modernize Install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ uninstall:
 develop-install: develop-uninstall
 	$(PIP) install --no-deps -e ./
 
-# known issue: It will fail to uninstall scripts
-#  if they were installed in develop mode
 develop-uninstall:
 	$(PIP) uninstall -y $(PACKAGE)
 
@@ -32,7 +30,7 @@ help:  ## Show this help.
 	@grep '##' Makefile| sed -e '/@/d' | sed -r 's,(.*?:).*##(.*),\1\2,g'
 
 dist:  ## Build setuptools dist
-	python setup.py sdist bdist_wheel
+	python -m build
 
 distupload: ## Upload package dist to PyPi
 	python -m twine upload --verbose dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools>=44"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "imaids"
+authors = [{ name = "lnls-ima" } ]
+maintainers = [
+  {name = "Gabriel Rezende de Ascenção", email = "gabriel.ascencao@lnls.br"},
+  {name = "Lucas Francisco"},
+]
+description = "Insertion Devices Package"
+readme = "README.md"
+dynamic = ["version", "dependencies"]
+requires-python = ">=3.6"
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering",
+]
+keywords = ["SIRIUS", "python", "Accelerator Physics", "Insertion Devices"]
+
+license = "MIT"
+license-files= [ "LICENSE", ]
+
+[project.urls]
+Homepage = "https://github.com/lnls-ima/insertion-devices"
+Download = "https://github.com/lnls-ima/insertion-devices"
+Repository = "https://github.com/lnls-ima/insertion-devices.git"
+Issues = "https://github.com/lnls-ima/insertion-devices/issues"
+
+[project.optional-dependencies]
+tests = ["nose"]
+
+# --- Setuptools specific configurations ---
+[tool.setuptools]
+packages = ["imaids"]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = { file = "VERSION" }
+dependencies = { file = "requirements.txt" }
+
+[tool.setuptools.package-data]
+imaids = ["VERSION", "presets/*"]

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 """Setup module."""
 
+import pathlib
+
 from setuptools import setup
-import pkg_resources
 
 
 def get_abs_path(relative):
-    """Get absolute path of file."""
-    return pkg_resources.resource_filename(__name__, relative)
+    """."""
+    return str(pathlib.Path(__file__).parent / relative)
 
 
 with open(get_abs_path("README.md"), "r") as _f:


### PR DESCRIPTION
Guys, please check the discussion on lnls-sirius/scripts#180.

I tried to make as few changes as possible. If you want not to support python3.6 anymore, it is possible to remove the setup.py file completly.

Besides, I noticed you have two python packages in this same repository, `imaids` and `idanalysis`,  but the old setup.py only installed the imaids. I would recommend you moving the idanalysis to other repository or keep it here, but creating an installation scheme for the idanalysis too.